### PR TITLE
this.Promise.resolve() -> new this.Promise()

### DIFF
--- a/src/command/Command.js
+++ b/src/command/Command.js
@@ -62,7 +62,7 @@ export default class Command {
     }
 
     execute() {
-        //Resolve promise to guarantee execution/fallback is always deferred
+        //Promise to guarantee execution/fallback is always deferred
         return new this.Promise((resolve) => {
                 if (this.requestVolumeRejectionThreshold != 0 && this.metrics.getCurrentExecutionCount() >= this.requestVolumeRejectionThreshold) {
                     return resolve(this.handleFailure(new Error("CommandRejected"), Array.prototype.slice.call(arguments)));

--- a/src/command/Command.js
+++ b/src/command/Command.js
@@ -63,16 +63,15 @@ export default class Command {
 
     execute() {
         //Resolve promise to guarantee execution/fallback is always deferred
-        return this.Promise.resolve()
-            .then(() => {
+        return new this.Promise((resolve) => {
                 if (this.requestVolumeRejectionThreshold != 0 && this.metrics.getCurrentExecutionCount() >= this.requestVolumeRejectionThreshold) {
-                    return this.handleFailure(new Error("CommandRejected"), Array.prototype.slice.call(arguments));
+                    return resolve(this.handleFailure(new Error("CommandRejected"), Array.prototype.slice.call(arguments)));
                 }
                 if (this.circuitBreaker.allowRequest()) {
-                    return this.runCommand.apply(this, arguments);
+                    return resolve(this.runCommand.apply(this, arguments));
                 } else {
                     this.metrics.markShortCircuited();
-                    return this.fallback(new Error("OpenCircuitError"), Array.prototype.slice.call(arguments));
+                    return resolve(this.fallback(new Error("OpenCircuitError"), Array.prototype.slice.call(arguments)));
                 }
             });
     }


### PR DESCRIPTION
This change is to resolve an instrumentation issue when using this module in conjunction with New Relic. New Relic fails to merge HystrixJS commands into an existing promise chain with using `Promise.resolve()`, and instead separately tracks them, causing incorrect total execution time metrics to be recorded.